### PR TITLE
Aggregate event counts and apply SDC functions

### DIFF
--- a/analysis/aggregate.py
+++ b/analysis/aggregate.py
@@ -1,0 +1,65 @@
+"""Aggregate event counts and apply Statistical Disclosure Control (SDC) functions.
+"""
+import pandas
+
+from analysis import sdc, utils
+
+
+def main():
+    d_in = utils.OUTPUT_DIR / "query"
+    event_counts = read(d_in / "rows.csv.gz")
+
+    d_out = utils.OUTPUT_DIR / "aggregate"
+    utils.makedirs(d_out)
+    aggregate(event_counts, "D", "sum").to_csv(d_out / "sum_by_day.csv.gz")
+    aggregate(event_counts, "W", "mean").to_csv(d_out / "mean_by_week.csv.gz")
+
+
+def read(f_in):
+    date_col = "event_date"
+    index_cols = ["table_name", date_col]
+    value_col = "event_count"
+    return (
+        pandas.read_csv(
+            f_in,
+            parse_dates=[date_col],
+            index_col=index_cols,
+            usecols=index_cols + [value_col],
+        )
+        .loc[:, value_col]
+        .sort_index()
+    )
+
+
+def aggregate(event_counts, offset, func):
+    group_by, resample_by = event_counts.index.names
+    return (
+        event_counts.pipe(resample, offset, func)
+        .pipe(sdc.redact_le_five)
+        .pipe(sdc.round_to_nearest_five)
+        .unstack(level=group_by)
+    )
+
+
+def resample(event_counts, offset, func):
+    """Resamples an irregular time series to a fixed frequency time series.
+
+    Args:
+        event_counts: An irregular time series.
+        offset: The unit to which event_counts is resampled [1].
+        func: The aggregation function [2].
+
+    [1]: https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#dateoffset-objects
+    [2]: http://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.core.resample.Resampler.aggregate.html#pandas.core.resample.Resampler.aggregate
+    """
+    group_by, resample_by = event_counts.index.names
+    return (
+        event_counts.groupby(level=group_by)
+        .resample(level=resample_by, rule=offset)
+        .aggregate(func)
+        .sort_index()
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/analysis/sdc.py
+++ b/analysis/sdc.py
@@ -1,0 +1,25 @@
+"""Statistical Disclosure Control (SDC) functions.
+
+For more information, see:
+https://docs.opensafely.org/releasing-files/
+"""
+import functools
+
+
+def redact_le(series, threshold):
+    copy_of_series = series.copy(deep=True)
+    copy_of_series[copy_of_series <= threshold] = 0
+    return copy_of_series
+
+
+redact_le_five = functools.partial(redact_le, threshold=5)
+
+
+def round_to_nearest(series, multiple):
+    def rounder(value):
+        return int(multiple * round(value / multiple, 0))
+
+    return series.apply(rounder)
+
+
+round_to_nearest_five = functools.partial(round_to_nearest, multiple=5)

--- a/project.yaml
+++ b/project.yaml
@@ -13,3 +13,10 @@ actions:
     outputs:
       highly_sensitive:
         rows: output/query/rows.csv.gz
+
+  aggregate:
+    needs: [query]
+    run: python:latest python -m analysis.aggregate
+    outputs:
+      moderately_sensitive:
+        aggregates: output/aggregate/*_by_*.csv.gz

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -1,0 +1,22 @@
+import pandas
+
+from analysis import aggregate
+
+
+def make_series(event_dates):
+    index = pandas.MultiIndex.from_product(
+        (["table_1", "table_2"], pandas.to_datetime(event_dates)),
+        names=("table_name", "event_date"),
+    )
+    return pandas.Series(index=index, data=1, name="event_count")
+
+
+def test_resample():
+    series = make_series(["2023-01-01", "2023-01-03"])
+    by_day = aggregate.resample(series, "D", "sum").reset_index()
+    assert [x.isoformat() for x in by_day["event_date"].dt.date] == [
+        "2023-01-01",
+        "2023-01-02",
+        "2023-01-03",
+    ] * 2
+    assert list(by_day["event_count"]) == [1, 0, 1] * 2

--- a/tests/test_sdc.py
+++ b/tests/test_sdc.py
@@ -1,0 +1,20 @@
+import pandas
+import pytest
+
+from analysis import sdc
+
+
+@pytest.mark.parametrize("data_in,data_out", [(4, 0), (5, 0), (6, 6)])
+def test_redact_le_five(data_in, data_out):
+    series = pandas.Series(data_in)
+    redacted_series = sdc.redact_le_five(series)
+    assert series is not redacted_series
+    assert list(redacted_series) == [data_out]
+
+
+@pytest.mark.parametrize("data_in,data_out", [(1, 0), (3, 5), (5, 5), (7, 5), (9, 10)])
+def test_round_to_nearest_five(data_in, data_out):
+    series = pandas.Series(data_in)
+    rounded_series = sdc.round_to_nearest_five(series)
+    assert series is not rounded_series
+    assert list(rounded_series) == [data_out]


### PR DESCRIPTION
The Statistical Disclosure Control (SDC) functions are located in `analysis.sdc` to signal their importance and to make them easier to reason about.

Rather than call `redact_le` and `round_to_nearest` directly, we create partial functions to make it clear to a reader of `analysis.aggregate` what we are redacting to and what we are rounding to, without them having to read `analysis.sdc`.