### PR TITLE
Plot aggregated event counts

### DIFF
--- a/analysis/plot.py
+++ b/analysis/plot.py
@@ -1,0 +1,62 @@
+"""Plot aggregated event counts.
+"""
+import itertools
+import textwrap
+
+import pandas
+from matplotlib import pyplot
+
+from analysis import utils
+
+
+def main():
+    d_in = utils.OUTPUT_DIR / "aggregate"
+    by_day = read(d_in / "sum_by_day.csv.gz")
+    by_week = read(d_in / "mean_by_week.csv.gz")
+
+    d_out = utils.OUTPUT_DIR / "plot"
+    utils.makedirs(d_out)
+
+    figs_cols = plot(by_day, by_week)
+    for fig, col in figs_cols:
+        f_stem = utils.slugify(col)
+        fig.savefig(d_out / f"{f_stem}.png")
+
+
+def read(f_in):
+    date_col = "event_date"
+    return pandas.read_csv(f_in, parse_dates=[date_col], index_col=[date_col])
+
+
+def plot(by_day, by_week):
+    cols = by_day.columns.union(by_week.columns)
+    min_ts = min(itertools.chain(by_day.index, by_week.index))
+    max_ts = max(itertools.chain(by_day.index, by_week.index))
+    for col in cols:
+        fig, ax = pyplot.subplots(figsize=(15, 7))
+
+        fig.suptitle(col, fontsize="x-large")
+        fig.text(
+            0,
+            0,
+            textwrap.dedent(
+                """
+                Event counts are based on raw data and should not be used for clinical or epidemiological inference.
+                Suppression and rounding have been applied to event counts.
+                """
+            ),
+        )
+
+        ax.plot(by_day.index, by_day[col])
+        ax.plot(by_week.index, by_week[col])
+
+        ax.grid(True)
+        ax.set_title(f"From {min_ts:%x} to {max_ts:%x}", fontsize="medium")
+        ax.set_ylabel("Event Counts")
+        ax.set_ylim(0)
+
+        yield fig, col
+
+
+if __name__ == "__main__":
+    main()

--- a/analysis/utils.py
+++ b/analysis/utils.py
@@ -1,6 +1,8 @@
 import functools
 import os
 import pathlib
+import re
+import unicodedata
 
 
 WORKSPACE_DIR = pathlib.Path(__file__).parents[1]
@@ -8,3 +10,18 @@ WORKSPACE_DIR = pathlib.Path(__file__).parents[1]
 OUTPUT_DIR = WORKSPACE_DIR / "output"
 
 makedirs = functools.partial(os.makedirs, exist_ok=True)
+
+
+def slugify(s):
+    # Based on Django's slugify. For more information, see:
+    # https://github.com/django/django/blob/4.1.7/django/utils/text.py#L399-L417
+
+    # convert to ASCII
+    s = unicodedata.normalize("NFKD", s).encode("ascii", "ignore").decode("ascii")
+    # remove characters that are not word, white space, or dash
+    s = re.sub(r"[^\w\s-]", "", s)
+    # replace one or more dash or one or more white space with one dash
+    s = re.sub(r"[-\s]+", "-", s)
+    # remove leading and trailing dashes and underscores
+    s = s.strip("-_")
+    return s.lower()

--- a/project.yaml
+++ b/project.yaml
@@ -20,3 +20,10 @@ actions:
     outputs:
       moderately_sensitive:
         aggregates: output/aggregate/*_by_*.csv.gz
+
+  plot:
+    needs: [aggregate]
+    run: python:latest python -m analysis.plot
+    outputs:
+      moderately_sensitive:
+        plots: output/plot/*.png

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,8 @@
+import pytest
+
+from analysis import utils
+
+
+@pytest.mark.parametrize("string,slug", [("Ça va?", "ca-va"), ("_so--so_", "so-so")])
+def test_slugify(string, slug):
+    assert utils.slugify(string) == slug


### PR DESCRIPTION
Because I'd like to get something working end-to-end, this is a first-pass at plotting aggregated event counts. Compare this plot, which represents dummy data

![apcs](https://user-images.githubusercontent.com/477263/231227850-99713f8d-a969-49aa-a5c9-1bf03ef1cc2c.png)

to one of the plots in [this notebook][1]. When I've assembled the plots that are generated by this code into a report, I'll return to this code to improve the plots 🙂.

Notice that we wish to plot sum-by-day on top of mean-by-week. However, the aggregates are stored in different data frames with different indexes (one at day frequency, one at week frequency). Consequently, we iterate over both column-by-column yielding a plot as we go.

[1]: https://github.com/opensafely/database-notebooks/blob/master/notebooks/database-history.ipynb