### PR TITLE
Render the report as an HTML file

### DIFF
--- a/analysis/render_report.py
+++ b/analysis/render_report.py
@@ -1,0 +1,63 @@
+"""Render the report as an HTML file using the Jinja templating engine.
+
+For more information about Jinja, see:
+<https://jinja.palletsprojects.com/en/2.11.x/>
+"""
+import base64
+import datetime
+import mimetypes
+
+from jinja2 import Environment, FileSystemLoader, StrictUndefined
+
+from analysis import utils
+
+
+ENVIRONMENT = Environment(
+    loader=FileSystemLoader(utils.ANALYSIS_DIR),
+    undefined=StrictUndefined,
+)
+
+
+def main():
+    f_out = utils.OUTPUT_DIR / "render_report" / "report.html"
+    utils.makedirs(f_out.parent)
+    rendered_report = render_report(
+        {
+            "tpp_epoch_date": datetime.date(2009, 1, 1),
+            "from_date": datetime.date(2016, 1, 1),  # analysis/query.sql
+            "to_date": datetime.date.today(),
+            "plots": sorted((utils.OUTPUT_DIR / "plot").glob("*.png")),
+        }
+    )
+    f_out.write_text(rendered_report, encoding="utf-8")
+
+
+def b64encode(path):
+    """Encodes the file at the given path using Base64.
+
+    Returns a string for use as the src attribute of an img tag. If we use this string,
+    then we embed the file within the HTML file. This means we don't have to include the
+    file in the list of outputs in project.yaml.
+    """
+    encoded = base64.b64encode(path.read_bytes()).decode("utf-8")
+    mtype, _ = mimetypes.guess_type(path)
+    return f"data:{mtype};base64, {encoded}"
+
+
+def date_format(date):
+    """Formats the given date as, for example, "1 January 2023"."""
+    return f"{date:%-d %B %Y}"  # the - removes the leading zero, but not on Windows
+
+
+# register template filters
+ENVIRONMENT.filters["b64encode"] = b64encode
+ENVIRONMENT.filters["date_format"] = date_format
+
+
+def render_report(data):
+    template = ENVIRONMENT.get_template("report_template.html")
+    return template.render(data)
+
+
+if __name__ == "__main__":
+    main()

--- a/analysis/report_template.html
+++ b/analysis/report_template.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+    <title>OpenSAFELY-TPP Database Historical Coverage</title>
+</head>
+
+<body>
+    <h1>OpenSAFELY-TPP Database Historical Coverage</h1>
+    <p>
+        This report displays the historical coverage of the OpenSAFELY-TPP database.
+        It is part of the OpenSAFELY platform's technical documentation
+        and is published at <a href="https://reports.opensafely.org/">https://reports.opensafely.org/</a>.
+    </p>
+    <p>
+        If you would like to use the OpenSAFELY platform, then you should read
+        our <a href="https://docs.opensafely.org/">documentation</a>,
+        our <a href="https://www.opensafely.org/about/">principles</a>,
+        and our process for <a href="https://www.opensafely.org/onboarding-new-users/">onboarding new users</a>.
+        If you would like to see the code we used to create this report,
+        then you can <a href="https://github.com/opensafely/tpp-database-history">view it on GitHub</a>.
+    </p>
+    <h2>Data Sources</h2>
+    <p>
+        The <a href="https://reports.opensafely.org/reports/opensafely-tpp-database-schema/"><em>OpenSAFELY-TPP Database Schema</em></a>
+        report contains information about the data sources in the OpenSAFELY-TPP database.
+    </p>
+    <h2>Report Run Date</h2>
+    <p>
+        This report was run on {{ to_date|date_format }}.
+        It reflects the state of the database on this date.
+    </p>
+    <h2>Event Activity</h2>
+    <p>
+        In the figures below,
+        <em>event activity</em> (counts of events, such as in-patient hospital admissions)
+        is reported for data sources from {{ from_date|date_format }} to {{ to_date|date_format }}.
+    </p>
+    <p>
+        The database only includes patients who were registered at GP practices using TPP's SystmOne clinical information system
+        (which is used by roughly 40% of GP practices)
+        on or after {{ tpp_epoch_date|date_format }},
+        including those patients who have since deregistered or died.
+        The database therefore captures event activity for these patients only.
+    </p>
+    {% for plot in plots %}
+    <p><img src="{{ plot|b64encode }}" title="Image generated from {{ plot }}"></p>
+    {% endfor %}
+</body>
+
+</html>

--- a/analysis/utils.py
+++ b/analysis/utils.py
@@ -7,6 +7,8 @@ import unicodedata
 
 WORKSPACE_DIR = pathlib.Path(__file__).parents[1]
 
+ANALYSIS_DIR = WORKSPACE_DIR / "analysis"
+
 OUTPUT_DIR = WORKSPACE_DIR / "output"
 
 makedirs = functools.partial(os.makedirs, exist_ok=True)

--- a/project.yaml
+++ b/project.yaml
@@ -27,3 +27,10 @@ actions:
     outputs:
       moderately_sensitive:
         plots: output/plot/*.png
+
+  render_report:
+    needs: [plot]
+    run: python:latest python -m analysis.render_report
+    outputs:
+      moderately_sensitive:
+        report: output/render_report/report.html


### PR DESCRIPTION
Here, we add the `render_report` action to render the report as an HTML file using the Jinja templating engine. We use the same method as opensafely-core/interactive-templates; that is, we encode the plots of aggregated event counts using Base64, so that we don't have to include them in the list of outputs in project.yaml.

The top of a report, with plots that represent dummy data, looks like this

![Screen Shot 2023-04-14 at 10 21 47](https://user-images.githubusercontent.com/477263/232003816-40fcbcc3-cb27-45b8-8040-3d54dbc4580a.png)

Compare it to [this notebook][1].

[1]: https://github.com/opensafely/database-notebooks/blob/master/notebooks/database-history.ipynb