### PR TITLE
Switch to opensafely-core/setup-action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,12 +10,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: "actions/setup-python@v4"
+      - uses: "opensafely-core/setup-action@v1"
         with:
           python-version: "3.8"
-          cache: "pip"
-          cache-dependency-path: requirements.*.txt
-      - uses: extractions/setup-just@v1
+          install-just: true
       - name: Check formatting, linting and import sorting
         run: just check
 
@@ -24,12 +22,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: "actions/setup-python@v4"
+      - uses: "opensafely-core/setup-action@v1"
         with:
           python-version: "3.8"
-          cache: "pip"
-          cache-dependency-path: requirements.*.txt
-      - uses: extractions/setup-just@v1
+          install-just: true
       - name: Run tests
         run: |
           just test


### PR DESCRIPTION
We switch from actions/setup-python and extractions/setup-just, to opensafely-core/setup-action for consistency with
opensafely-core/repo-template.