### PR TITLE
Add plots from 2020

### DIFF
--- a/analysis/click_types.py
+++ b/analysis/click_types.py
@@ -1,0 +1,26 @@
+import datetime
+import pathlib
+
+import click
+
+
+class Date(click.ParamType):
+    """The Date type converts date strings into datetime.date objects."""
+
+    name = "Date"
+
+    def convert(self, value, param, ctx):
+        return datetime.date.fromisoformat(value)
+
+
+class Path(click.Path):
+    """The Path type converts path strings into pathlib.Path objects.
+
+    This conversion is supported by Click>=8.0.
+    """
+
+    name = "Path"
+
+    def convert(self, value, param, ctx):
+        path = super().convert(value, param, ctx)
+        return pathlib.Path(path)

--- a/analysis/config.py
+++ b/analysis/config.py
@@ -1,7 +1,6 @@
 import datetime
 
 
-# If you change the values of these variables, then also change their equivalents in
+# If you change the value of this variable, then also change its equivalent in
 # analysis/query.sql.
-FROM_DATE = datetime.date(2016, 1, 1)
 TO_DATE = datetime.date.today()

--- a/analysis/report_template.html
+++ b/analysis/report_template.html
@@ -35,7 +35,7 @@
     <p>
         In the figures below,
         <em>event activity</em> (counts of events, such as in-patient hospital admissions)
-        is reported for data sources from {{ from_date|date_format }} to {{ to_date|date_format }}.
+        is reported for data sources from the given date to {{ to_date|date_format }}.
     </p>
     <p>
         The database only includes patients who were registered at GP practices using TPP's SystmOne clinical information system
@@ -52,7 +52,9 @@
     </ul>
     {% for plot in plots %}
     <h3 id="{{ plot.stem }}">{{ plot.stem }}</h3>
-    <p><img src="{{ plot|b64encode }}" title="Image generated from {{ plot }}"></p>
+    {% for path in plot.paths %}
+    <p><img src="{{ path|b64encode }}" title="Image generated from {{ path }}"></p>
+    {% endfor %}
     {% endfor %}
 </body>
 

--- a/project.yaml
+++ b/project.yaml
@@ -23,7 +23,10 @@ actions:
 
   plot:
     needs: [aggregate]
-    run: python:latest python -m analysis.plot
+    run: >
+      python:latest python -m analysis.plot
+        --from-date 2016-01-01
+        --output output/plot
     outputs:
       moderately_sensitive:
         plots: output/plot/*.png

--- a/project.yaml
+++ b/project.yaml
@@ -21,18 +21,28 @@ actions:
       moderately_sensitive:
         aggregates: output/aggregate/*_by_*.csv.gz
 
-  plot:
+  plot_from_2016:
     needs: [aggregate]
     run: >
       python:latest python -m analysis.plot
         --from-date 2016-01-01
-        --output output/plot
+        --output output/plot_from_2016
     outputs:
       moderately_sensitive:
-        plots: output/plot/*.png
+        plots: output/plot_from_2016/*.png
+
+  plot_from_2020:
+    needs: [aggregate]
+    run: >
+      python:latest python -m analysis.plot
+        --from-date 2020-02-01
+        --output output/plot_from_2020
+    outputs:
+      moderately_sensitive:
+        plots: output/plot_from_2020/*.png
 
   render_report:
-    needs: [plot]
+    needs: [plot_from_2016, plot_from_2020]
     run: python:latest python -m analysis.render_report
     outputs:
       moderately_sensitive:


### PR DESCRIPTION
In this PR, we add new plots from 2020 to the present, alongside existing plots from 2016 to the present.

Previously, we had database builds and database history notebooks. The former had some plots that were very similar to the latter, so opensafely/database-notebooks#35 suggested combining them.

There are three things to combine: plots from 2020 to the present; plots for the last 30 days of event activity; and tables/plots that capture when the different datasets were loaded into the TPP database. In this PR, we achieve the first thing: plots from 2020. The second thing will happen in another PR; the third thing will (probably) happen in another repo, as it concerns metadata rather than data.

You'll notice that I've opted for `click` over `argparse`. I did so because I wanted to write less, more reliable code that didn't get in the way of the enclosing script.