### PR TITLE
`redact_le_five` -> `redact_le_seven`

### DIFF
--- a/analysis/aggregate.py
+++ b/analysis/aggregate.py
@@ -47,7 +47,7 @@ def aggregate(event_counts, offset, func):
     group_by, resample_by = event_counts.index.names
     return (
         event_counts.pipe(resample, offset, func)
-        .pipe(sdc.redact_le_five)
+        .pipe(sdc.redact_le_seven)
         .pipe(sdc.round_to_nearest_five)
         .unstack(level=group_by)
     )

--- a/analysis/sdc.py
+++ b/analysis/sdc.py
@@ -12,7 +12,7 @@ def redact_le(series, threshold):
     return copy_of_series
 
 
-redact_le_five = functools.partial(redact_le, threshold=5)
+redact_le_seven = functools.partial(redact_le, threshold=7)
 
 
 def round_to_nearest(series, multiple):

--- a/tests/test_sdc.py
+++ b/tests/test_sdc.py
@@ -4,10 +4,10 @@ import pytest
 from analysis import sdc
 
 
-@pytest.mark.parametrize("data_in,data_out", [(4, 0), (5, 0), (6, 6)])
-def test_redact_le_five(data_in, data_out):
+@pytest.mark.parametrize("data_in,data_out", [(6, 0), (7, 0), (8, 8)])
+def test_redact_le_seven(data_in, data_out):
     series = pandas.Series(data_in)
-    redacted_series = sdc.redact_le_five(series)
+    redacted_series = sdc.redact_le_seven(series)
     assert series is not redacted_series
     assert list(redacted_series) == [data_out]
 


### PR DESCRIPTION
Raises the threshold from five to seven, following a request from @ccunningham101. This is consistent with the advice in the OpenSAFELY documentation on [Rounding counts][1].

[1]: https://docs.opensafely.org/releasing-files/#rounding-counts