### PR TITLE
Don't compress outputs

### DIFF
--- a/analysis/aggregate.py
+++ b/analysis/aggregate.py
@@ -11,8 +11,8 @@ def main():
 
     d_out = utils.OUTPUT_DIR / "aggregate"
     utils.makedirs(d_out)
-    aggregate(event_counts, "D", "sum").to_csv(d_out / "sum_by_day.csv.gz")
-    aggregate(event_counts, "W", "mean").to_csv(d_out / "mean_by_week.csv.gz")
+    aggregate(event_counts, "D", "sum").to_csv(d_out / "sum_by_day.csv")
+    aggregate(event_counts, "W", "mean").to_csv(d_out / "mean_by_week.csv")
 
 
 def read(f_in):

--- a/project.yaml
+++ b/project.yaml
@@ -19,7 +19,7 @@ actions:
     run: python:latest python -m analysis.aggregate
     outputs:
       moderately_sensitive:
-        aggregates: output/aggregate/*_by_*.csv.gz
+        aggregates: output/aggregate/*_by_*.csv
 
   plot_from_2016:
     needs: [aggregate]


### PR DESCRIPTION
...on L4. It's easier for output checkers if the outputs aren't compressed. (We still want compressed outputs on L3.)

Closes #74