### PR TITLE
Fix `aggregate`

### DIFF
--- a/analysis/aggregate.py
+++ b/analysis/aggregate.py
@@ -46,7 +46,9 @@ def read(f_in):
 def aggregate(event_counts, offset, func):
     group_by, resample_by = event_counts.index.names
     return (
-        event_counts.pipe(resample, offset, func)
+        event_counts.round()  # to nearest integer
+        .astype(int)
+        .pipe(resample, offset, func)
         .pipe(sdc.redact_le_seven)
         .pipe(sdc.round_to_nearest_five)
         .unstack(level=group_by)

--- a/analysis/sdc.py
+++ b/analysis/sdc.py
@@ -17,7 +17,7 @@ redact_le_seven = functools.partial(redact_le, threshold=7)
 
 def round_to_nearest(series, multiple):
     def rounder(value):
-        # raises ValueError when value = float("NaN")
+        assert isinstance(value, int), f"The value to round ({value}) must be an int"
         return int(multiple * round(value / multiple, 0))
 
     return series.apply(rounder)

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -5,20 +5,20 @@ from pandas.testing import assert_frame_equal
 from analysis import aggregate
 
 
-def test_read_with_unparsable_date(tmp_path):
-    rows_csv = tmp_path / "rows.csv"
-    unparsable_date = "9999-01-01"
-    rows_csv.write_text(f"table_name,event_date,event_count\nAPCS,{unparsable_date},1")
-    with pytest.raises(AssertionError):
-        aggregate.read(rows_csv)
-
-
 def make_series(event_dates):
     index = pandas.MultiIndex.from_product(
         (["table_1", "table_2"], pandas.to_datetime(event_dates)),
         names=("table_name", "event_date"),
     )
     return pandas.Series(index=index, data=1, name="event_count")
+
+
+def test_read_with_unparsable_date(tmp_path):
+    rows_csv = tmp_path / "rows.csv"
+    unparsable_date = "9999-01-01"
+    rows_csv.write_text(f"table_name,event_date,event_count\nAPCS,{unparsable_date},1")
+    with pytest.raises(AssertionError):
+        aggregate.read(rows_csv)
 
 
 def test_aggregate_sum_by_day():

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -1,17 +1,8 @@
-import functools
-
 import pandas
 import pytest
 from pandas.testing import assert_frame_equal
 
 from analysis import aggregate
-
-
-assert_series_equal = functools.partial(
-    pandas.testing.assert_series_equal,
-    check_dtype=False,
-    check_names=False,
-)
 
 
 def test_read_with_unparsable_date(tmp_path):
@@ -30,6 +21,23 @@ def make_series(event_dates):
     return pandas.Series(index=index, data=1, name="event_count")
 
 
+def test_aggregate_sum_by_day():
+    series = make_series(["2023-01-01", "2023-01-03"])
+    series.loc[("table_1",)] = 7
+    series.loc[("table_2",)] = 8
+    sum_by_day = aggregate.aggregate(series, "D", "sum")
+    assert_frame_equal(
+        sum_by_day,
+        pandas.DataFrame(
+            [(0, 10), (0, 0), (0, 10)],  # rows
+            index=pandas.DatetimeIndex(
+                ["2023-01-01", "2023-01-02", "2023-01-03"], name="event_date"
+            ),
+            columns=pandas.Index(["table_1", "table_2"], name="table_name"),
+        ),
+    )
+
+
 def test_aggregate_mean_by_week():
     series = make_series(["2023-01-01", "2023-01-03"])
     series.loc[("table_1",)] = 7.1
@@ -43,16 +51,3 @@ def test_aggregate_mean_by_week():
             columns=pandas.Index(["table_1", "table_2"], name="table_name"),
         ),
     )
-
-
-@pytest.mark.parametrize("func,exp", [("sum", [1, 0, 1]), ("mean", [1, 0, 1])])
-def test_resample(func, exp):
-    series = make_series(["2023-01-01", "2023-01-03"])
-    by_day = aggregate.resample(series, "D", func).reset_index()
-    assert_series_equal(
-        by_day["event_date"],
-        pandas.Series(
-            pandas.to_datetime(["2023-01-01", "2023-01-02", "2023-01-03"] * 2)
-        ),
-    )
-    assert_series_equal(by_day["event_count"], pandas.Series(exp * 2))

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -5,9 +5,9 @@ from pandas.testing import assert_frame_equal
 from analysis import aggregate
 
 
-def make_event_counts(event_dates):
+def make_event_counts(table_names, event_dates):
     index = pandas.MultiIndex.from_product(
-        (["table_1", "table_2"], pandas.to_datetime(event_dates)),
+        (table_names, pandas.to_datetime(event_dates)),
         names=("table_name", "event_date"),
     )
     return pandas.Series(index=index, data=1, name="event_count")
@@ -22,7 +22,7 @@ def test_read_with_unparsable_date(tmp_path):
 
 
 def test_aggregate_sum_by_day():
-    series = make_event_counts(["2023-01-01", "2023-01-03"])
+    series = make_event_counts(["table_1", "table_2"], ["2023-01-01", "2023-01-03"])
     series.loc[("table_1",)] = 7
     series.loc[("table_2",)] = 8
     sum_by_day = aggregate.aggregate(series, "D", "sum")
@@ -39,7 +39,7 @@ def test_aggregate_sum_by_day():
 
 
 def test_aggregate_mean_by_week():
-    series = make_event_counts(["2023-01-01", "2023-01-03"])
+    series = make_event_counts(["table_1", "table_2"], ["2023-01-01", "2023-01-03"])
     series.loc[("table_1",)] = 7.1
     series.loc[("table_2",)] = 7.5
     mean_by_week = aggregate.aggregate(series, "W", "mean")

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -46,7 +46,7 @@ def test_aggregate_mean_by_week():
     assert_frame_equal(
         mean_by_week,
         pandas.DataFrame(
-            [(5, 10), (5, 10)],  # rows
+            [(0, 10), (0, 10)],  # rows
             index=pandas.DatetimeIndex(["2022-12-25", "2023-01-01"], name="event_date"),
             columns=pandas.Index(["table_1", "table_2"], name="table_name"),
         ),

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -2,6 +2,7 @@ import functools
 
 import pandas
 import pytest
+from pandas.testing import assert_frame_equal
 
 from analysis import aggregate
 
@@ -27,6 +28,21 @@ def make_series(event_dates):
         names=("table_name", "event_date"),
     )
     return pandas.Series(index=index, data=1, name="event_count")
+
+
+def test_aggregate_mean_by_week():
+    series = make_series(["2023-01-01", "2023-01-03"])
+    series.loc[("table_1",)] = 7.1
+    series.loc[("table_2",)] = 7.5
+    mean_by_week = aggregate.aggregate(series, "W", "mean")
+    assert_frame_equal(
+        mean_by_week,
+        pandas.DataFrame(
+            [(5, 10), (5, 10)],  # rows
+            index=pandas.DatetimeIndex(["2022-12-25", "2023-01-01"], name="event_date"),
+            columns=pandas.Index(["table_1", "table_2"], name="table_name"),
+        ),
+    )
 
 
 @pytest.mark.parametrize("func,exp", [("sum", [1, 0, 1]), ("mean", [1, 0, 1])])

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -5,7 +5,7 @@ from pandas.testing import assert_frame_equal
 from analysis import aggregate
 
 
-def make_series(event_dates):
+def make_event_counts(event_dates):
     index = pandas.MultiIndex.from_product(
         (["table_1", "table_2"], pandas.to_datetime(event_dates)),
         names=("table_name", "event_date"),
@@ -22,7 +22,7 @@ def test_read_with_unparsable_date(tmp_path):
 
 
 def test_aggregate_sum_by_day():
-    series = make_series(["2023-01-01", "2023-01-03"])
+    series = make_event_counts(["2023-01-01", "2023-01-03"])
     series.loc[("table_1",)] = 7
     series.loc[("table_2",)] = 8
     sum_by_day = aggregate.aggregate(series, "D", "sum")
@@ -39,7 +39,7 @@ def test_aggregate_sum_by_day():
 
 
 def test_aggregate_mean_by_week():
-    series = make_series(["2023-01-01", "2023-01-03"])
+    series = make_event_counts(["2023-01-01", "2023-01-03"])
     series.loc[("table_1",)] = 7.1
     series.loc[("table_2",)] = 7.5
     mean_by_week = aggregate.aggregate(series, "W", "mean")

--- a/tests/test_sdc.py
+++ b/tests/test_sdc.py
@@ -18,9 +18,3 @@ def test_round_to_nearest_five(data_in, data_out):
     rounded_series = sdc.round_to_nearest_five(series)
     assert series is not rounded_series
     assert list(rounded_series) == [data_out]
-
-
-def test_round_to_nearest_five_with_float_nan():
-    with pytest.raises(ValueError) as e:
-        sdc.round_to_nearest_five(pandas.Series([1, None]))
-    assert str(e.value) == "cannot convert float NaN to integer"


### PR DESCRIPTION
When the resampling function produced a series of floats, as was the case when it was the mean, values greater than 7.0 but less than 7.5 would be rounded down to 5. Now, values are rounded to the nearest integer and the series is cast to an `int`, so values in this range will be either redacted (e.g. 7.1 -> 7 -> 0) or rounded up to 10 (e.g. 7.5 -> 8 -> 10).

Thanks for spotting the bug in ebmdatalab/opensafely-output-review#719, @LFISHER7 and @Jongmassey. I've a couple more issues with this report to address, but will run and request a release when I'm done.

Closes #93