### PR TITLE
Add `test_runner.yaml`

### DIFF
--- a/.github/workflows/test_runner.yaml
+++ b/.github/workflows/test_runner.yaml
@@ -1,0 +1,17 @@
+name: Test that the project is runnable
+
+on: [push, workflow_dispatch]
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  DOCKER_RO_TOKEN: ${{ secrets.DOCKER_RO_TOKEN }}
+  STATA_LICENSE: ${{ secrets.STATA_LICENSE }}
+  HONEYCOMB_API_KEY: ${{ secrets.HONEYCOMB_API_KEY }}
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    name: Test the project can run, using dummy data
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Test that the project is runnable
+      uses: opensafely-core/research-action@v2

--- a/analysis/plot.py
+++ b/analysis/plot.py
@@ -26,8 +26,8 @@ def main(from_date, from_offset, d_out):
     assert (from_date is not None) or (from_offset is not None)
 
     d_in = utils.OUTPUT_DIR / "aggregate"
-    by_day = read(d_in / "sum_by_day.csv.gz")
-    by_week = read(d_in / "mean_by_week.csv.gz")
+    by_day = read(d_in / "sum_by_day.csv")
+    by_week = read(d_in / "mean_by_week.csv")
 
     if from_date is not None:
         by_day_date_ranges = get_date_ranges_from_date(by_day, from_date)


### PR DESCRIPTION
This adds the latest version of `test_runner.yaml` from opensafely/research-template. It also fixes an issue with `analysis/plot.py` (introduced by 83520f3) that was identified by testing that the project is runnable.