### PR TITLE
Rename notebook to avoid use of "historical"

### DIFF
--- a/analysis/report_template.html
+++ b/analysis/report_template.html
@@ -3,13 +3,13 @@
 
 <head>
     <meta charset="utf-8">
-    <title>OpenSAFELY-TPP Database Historical Coverage</title>
+    <title>OpenSAFELY-TPP Database Coverage</title>
 </head>
 
 <body>
-    <h1>OpenSAFELY-TPP Database Historical Coverage</h1>
+    <h1>OpenSAFELY-TPP Database Coverage</h1>
     <p>
-        This report displays the historical coverage of the OpenSAFELY-TPP database.
+        This report displays the coverage of the OpenSAFELY-TPP database.
         It is part of the OpenSAFELY platform's technical documentation
         and is published at <a href="https://reports.opensafely.org/">https://reports.opensafely.org/</a>.
     </p>


### PR DESCRIPTION
It's significantly more work to rename the repo and workspace, so I've simply removed references to "historical" from the notebook and updated the entry on <https://reports.opensafely.org/>.

The repo and workspace contain the word "history" rather than "historical", so I think that not renaming them is okay.

Closes #64