### PR TITLE
Write files for release to separate directory

### DIFF
--- a/analysis/__init__.py
+++ b/analysis/__init__.py
@@ -5,3 +5,6 @@ WORKSPACE_DIR = pathlib.Path(__file__).parents[1]
 ANALYSIS_DIR = WORKSPACE_DIR / "analysis"
 
 OUTPUT_DIR = WORKSPACE_DIR / "output"
+
+# Output and supporting files/dirs for release
+RELEASE_DIR = OUTPUT_DIR / "files_for_release"

--- a/analysis/aggregate.py
+++ b/analysis/aggregate.py
@@ -6,7 +6,7 @@ https://docs.opensafely.org/releasing-files/
 
 import pandas
 
-from analysis import OUTPUT_DIR, utils
+from analysis import OUTPUT_DIR, RELEASE_DIR, utils
 
 SUPPRESSION_THRESHOLD = 7
 ROUNDING_MULTIPLE = 5
@@ -16,7 +16,7 @@ def main():
     d_in = OUTPUT_DIR / "query"
     event_counts = read(d_in / "rows.csv.gz")
 
-    d_out = OUTPUT_DIR / "aggregate"
+    d_out = RELEASE_DIR / "aggregate"
     utils.makedirs(d_out)
     aggregate(event_counts, sum_by_day_resampler).to_csv(d_out / "sum_by_day.csv")
     aggregate(event_counts, mean_by_week_resampler).to_csv(d_out / "mean_by_week.csv")

--- a/analysis/plot.py
+++ b/analysis/plot.py
@@ -11,7 +11,7 @@ import click
 import pandas
 from matplotlib import pyplot
 
-from analysis import OUTPUT_DIR, utils
+from analysis import RELEASE_DIR, utils
 
 
 class ClickTimestamp(click.ParamType):
@@ -50,7 +50,7 @@ def main(from_date, from_offset, d_out):
     # why), so this ensures that at least one from_* option is set.
     assert (from_date is not None) or (from_offset is not None)
 
-    d_in = OUTPUT_DIR / "aggregate"
+    d_in = RELEASE_DIR / "aggregate"
     by_day = read(d_in / "sum_by_day.csv")
     by_week = read(d_in / "mean_by_week.csv")
 

--- a/analysis/render_report.py
+++ b/analysis/render_report.py
@@ -13,7 +13,7 @@ import pathlib
 
 from jinja2 import Environment, FileSystemLoader, StrictUndefined
 
-from analysis import ANALYSIS_DIR, OUTPUT_DIR, utils
+from analysis import ANALYSIS_DIR, OUTPUT_DIR, RELEASE_DIR, utils
 
 ENVIRONMENT = Environment(
     loader=FileSystemLoader(ANALYSIS_DIR),
@@ -22,7 +22,7 @@ ENVIRONMENT = Environment(
 
 
 def main():
-    f_out = OUTPUT_DIR / "render_report" / "report.html"
+    f_out = RELEASE_DIR / "render_report" / "report.html"
     utils.makedirs(f_out.parent)
     rendered_report = render_report(
         {

--- a/project.yaml
+++ b/project.yaml
@@ -22,7 +22,7 @@ actions:
     run: python:latest python -m analysis.aggregate
     outputs:
       moderately_sensitive:
-        aggregates: output/aggregate/*_by_*.csv
+        aggregates: output/files_for_release/aggregate/*_by_*.csv
 
   plot_from_2016:
     needs: [query, aggregate]
@@ -62,4 +62,4 @@ actions:
     run: python:latest python -m analysis.render_report
     outputs:
       moderately_sensitive:
-        report: output/render_report/report.html
+        report: output/files_for_release/render_report/report.html


### PR DESCRIPTION
To allow us to automate release requests for this workspace, write the file to be released (report.html) and the supporting aggregate files to the same containing directory. This means we can set up the release request so that both output and supporting files are added to the same group.

Fixes #220 